### PR TITLE
Fixed a bug where a stack overflow would be caused from the getDataAsObject method

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
 	name: "krstffr:reactive-constructor",
   summary: "Create reactive objects from these constructors.",
-	version: "1.2.2"
+	version: "1.2.3"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Fixed a bug where a stack overflow would be caused when the getDataAsObject method returns the parentInstance link (which links to the parent context = infinite loop).
